### PR TITLE
Resolve pipeline startup failures or failed camera discovery with cam-sn

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Several properties are implemented to control the function of the source plugin.
 
 
 #### cam-serial-number
-Specifies serial number of the camera to open. If no serial number is specified the plugin will open the first found RealSense device.
+Specifies serial number of the camera to open. If no serial number is specified the plugin will open the first found RealSense device. To discover serial numbers rs-enumerate-devices can be utilized (for details see https://github.com/IntelRealSense/librealsense/blob/master/tools/enumerate-devices/readme.md)
 
 #### align 
 Controls the alignement between the color and depth frames.

--- a/src/gstrealsensesrc.h
+++ b/src/gstrealsensesrc.h
@@ -50,7 +50,7 @@ typedef struct _GstRealsenseSrcClass GstRealsenseSrcClass;
 
 using rs_pipe_ptr = std::unique_ptr<rs2::pipeline>;
 using rs_aligner_ptr = std::unique_ptr<rs2::align>;
-constexpr const auto DEFAULT_PROP_CAM_SN = 0;
+constexpr const auto DEFAULT_PROP_CAM_SN = "";
 
 struct _GstRealsenseSrc
 {
@@ -78,7 +78,7 @@ struct _GstRealsenseSrc
   
   // Properties
   Align align = Align::None;
-  guint64 serial_number = 0;
+  std::string serial_number;
   StreamType stream_type = StreamType::StreamDepth;
   bool imu_on = true;
 };


### PR DESCRIPTION
1. Give info on how to discover serial numbers from cameras
2. Convert serial-number to string since some numbers start with zero
3. Only enable motion if IMU is supported to prevent startup failures
4. Only utilize camera metadata actual_exposure if supported by camera to prevent startup failures